### PR TITLE
Blog typos

### DIFF
--- a/site/.vuepress/enhanceApp.js
+++ b/site/.vuepress/enhanceApp.js
@@ -237,7 +237,7 @@ const redirectList = [
   },
   {
     path: "/field-guide/",
-    redirect: "/guide/",
+    redirect: "/tag/field-guide",
   },
   {
     path: "/field-guide/well-packaged-datasets/",

--- a/site/.vuepress/enhanceApp.js
+++ b/site/.vuepress/enhanceApp.js
@@ -273,11 +273,11 @@ const redirectList = [
   },
   {
     path: "/universe/",
-    redirect: "/data-package/",
+    redirect: "/adoption/",
   },
   {
     path: "/docs/data-package/",
-    redirect: "/data-package/",
+    redirect: "/introduction/",
   },
   {
     path: "/docs/table-schema/",
@@ -301,7 +301,7 @@ const redirectList = [
   },
   {
     path: "/data-package/",
-    redirect: "/about/introduction/",
+    redirect: "/introduction/",
   },
   {
     path: "/tooling/application/",

--- a/site/adoption/README.md
+++ b/site/adoption/README.md
@@ -474,7 +474,7 @@ In 2021, we partnered with the Open Data Institute (ODI) to improve our existing
 
 ### Frictionless Field Guide
 
-In 2017, OKF received funding from the Open Data Institute to create a Frictionless Data Field Guide. This guide provided step-by-step instructions for improving data publishing workflows. The field guide introduced new ways of working informed by the Frictionless Data suite of software that data publishers can use independently, or adapt into existing personal and organisational workflows. You can read more details about this work [here](https://blog.okfn.org/2018/03/27/improving-your-data-publishing-workflow-with-the-frictionless-data-field-guide/).
+In 2017, OKF received funding from the Open Data Institute to create a Frictionless Data Field Guide. This guide provided step-by-step instructions for improving data publishing workflows. The [field guide](/tag/field-guide) introduced new ways of working informed by the Frictionless Data suite of software that data publishers can use independently, or adapt into existing personal and organisational workflows. You can read more details about this work [here](https://blog.okfn.org/2018/03/27/improving-your-data-publishing-workflow-with-the-frictionless-data-field-guide/).
 
 ### Data Package Integrations
 

--- a/site/blog/2016-04-20-publish-faq/README.md
+++ b/site/blog/2016-04-20-publish-faq/README.md
@@ -7,15 +7,13 @@ category: publishing-data
 
 FAQs and best practice patterns for publishing data packages.
 
-<!-- more -->
 Complete specifications are available at [specs/data-package](https://specs.frictionlessdata.io/data-package/).
 
 ## Data Package Name
 
 The Data Package name is used in the `name` field of the `datapackage.json`.
 
-*This name is also frequently used for the folder/directory in which the Data
-Package is stored.*
+*This name is also frequently used for the folder/directory in which the Data Package is stored.*
 
 As per the Data Package spec The name SHOULD be:
 
@@ -50,16 +48,14 @@ Similar to Data Package Names:
 * lower-case
 * use '-' for word separators
 
-Resource names SHOULD, usually, be the same as the name of the associated file
-on disk but without the file extension. e.g.
+Resource names SHOULD, usually, be the same as the name of the associated file on disk but without the file extension. e.g.
 
 ```
 gdp-quarterly     # resource name
 gdp-quarterly.csv # on disk
 ```
 
-Naming conventions of files follow that for data packages in terms of country
-or time series facets.
+Naming conventions of files follow that for data packages in terms of country or time series facets.
 
 ----
 
@@ -67,9 +63,7 @@ or time series facets.
 
 ### Alignment
 
-With JSON, data is structured in a nested way through curly and squared
-brackets. Though the alignment of these structures is not relevant for computer
-programs, it makes it easier for the human reader if they are properly aligned.
+With JSON, data is structured in a nested way through curly and squared brackets. Though the alignment of these structures is not relevant for computer programs, it makes it easier for the human reader if they are properly aligned.
 
 Good alignment:
 
@@ -101,29 +95,21 @@ Bad alignment:
 }
 ```
 
-Please make sure to have your `datapackage.json` well structured to ease the
-understanding of your Data Package content. The [Online DataPackage.json
-Creator](https://packagist.org/) can help you create the general
-structure.
+Please make sure to have your `datapackage.json` well structured to ease the understanding of your Data Package content. The [Online DataPackage.json Creator](https://create.frictionlessdata.io/) can help you create the general structure.
 
 ### Contributors fields
 
-Add the 'contributors' field (original author of the package - see
-[specs/data-package](https://specs.frictionlessdata.io/data-package/) if you wish to keep the credits for the
-package.
+Add the 'contributors' field (original author of the package - see [specs/data-package](https://specs.frictionlessdata.io/data-package/) if you wish to keep the credits for the package.
 
 ----
 
 ## Data Package Folder Names and Structure
 
-It is standard practice to use the Data Package name (from the
-`datapackage.json`) for the name of the folder/directory in which the Data
-Package is kept.
+It is standard practice to use the Data Package name (from the `datapackage.json`) for the name of the folder/directory in which the Data Package is kept.
 
 If storing in e.g. git(hub) this would also be the the name of the repository.
 
-If you include scripts allowing to automate the data extraction process, these
-should be stored in a `script` folder/directory.
+If you include scripts allowing to automate the data extraction process, these should be stored in a `script` folder/directory.
 
 ----
 
@@ -135,25 +121,19 @@ Data Packages SHOULD have a README.
 
 ### Formatting
 
-The README SHOULD be a plain text file (no word or rich text etc) and SHOULD
-use markdown to allow for formatting
+The README SHOULD be a plain text file (no word or rich text etc) and SHOULD use markdown to allow for formatting
 
 ### File Name
 
-If markdown is used the file SHOULD be named `README.md` and otherwise SHOULD
-be named `README.txt`.
+If markdown is used the file SHOULD be named `README.md` and otherwise SHOULD be named `README.txt`.
 
 ### Sections
 
-You can include anything you like in your README. It is standard practice to
-include some (if possible all) of the following sections: **Introduction, Data,
-Preparation, License**.
+You can include anything you like in your README. It is standard practice to include some (if possible all) of the following sections: **Introduction, Data, Preparation, License**.
 
 We SHOULD NOT include the title of the Data Package at the top of the README.
 
-Each section other than the introduction should be headed with its name using
-level 2 heading in markdown e.g. for the data section you would have the
-following markdown in your README:
+Each section other than the introduction should be headed with its name using level 2 heading in markdown e.g. for the data section you would have the following markdown in your README:
 
 ```
 ## Data
@@ -161,33 +141,23 @@ following markdown in your README:
 
 #### Introduction
 
-Start with a short description of the dataset (the first sentence and first
-paragraph should be extractable to provide short standalone descriptions).
+Start with a short description of the dataset (the first sentence and first paragraph should be extractable to provide short standalone descriptions).
 
-Unlike other sections **this section SHOULD NOT have a heading** as it starts
-the README. (i.e. you do not need the heading `## Introduction`
+Unlike other sections **this section SHOULD NOT have a heading** as it starts the README. (i.e. you do not need the heading `## Introduction`
 
 #### Data
 
-Put specific information about the data in a Data section. This can be things
-like information about the source of the data, the specific structure of the
-data, missing values etc.
+Put specific information about the data in a Data section. This can be things like information about the source of the data, the specific structure of the data, missing values etc.
 
 #### Preparation
 
-Put information on preparing the data in a Preparation section. In particular,
-any instructions about how to run any preparation and processing scripts to
-generate the data should go here.
+Put information on preparing the data in a Preparation section. In particular, any instructions about how to run any preparation and processing scripts to generate the data should go here.
 
 #### License
 
-Put additional information on the permissions and licensing of the data in the
-Data Package in the License section.
+Put additional information on the permissions and licensing of the data in the Data Package in the License section.
 
-Since licensing information is often not clear from the data producers, the
-guideline here is to license the Data Package under the Public Domain
-Dedication and License, and then to add any relevant information or disclaimers
-regarding the source data.
+Since licensing information is often not clear from the data producers, the guideline here is to license the Data Package under the Public Domain Dedication and License, and then to add any relevant information or disclaimers regarding the source data.
 
 See, for example:
 
@@ -200,13 +170,9 @@ See also the following thread <https://discuss.okfn.org/t/copyright-on-data-sour
 
 ## Validate and preview your Data Package
 
-Use the [Data Package Creator][dp-creator] to check that your `datapackage.json`
-and Data Package are good to go. Simply drop the URL to your `datapackage.json` file in
-the input box, or upload from a local source, and press `Validate`. If everything is fine, `Status: Valid` is
-returned.
+Use the [Data Package Creator][dp-creator] to check that your `datapackage.json` and Data Package are good to go. Simply drop the URL to your `datapackage.json` file in the input box, or upload from a local source, and press `Validate`. If everything is fine, `Status: Valid` is returned.
 
-Then use the [Online Data Package viewer app][dp-viewer] to have a preview of
-your Data Package.
+Then use the [Online Data Package viewer app][dp-viewer] to have a preview of your Data Package.
 
 ----
 
@@ -238,7 +204,7 @@ Recommended reading: Find out how to use Frictionless Data software to improve y
 [pub-any]: /blog/2016/07/21/publish-any/
 [pub-geo]: /blog/2016/04/30/publish-geo/
 [pub-faq]: /blog/2016/04/20/publish-faq/
-[field-guide]: /data-package
+[field-guide]: /tag/field-guide
 
 [dp-creator]: http://create.frictionlessdata.io
 [dp-viewer]: http://create.frictionlessdata.io

--- a/site/blog/2016-04-30-publish-geo/README.md
+++ b/site/blog/2016-04-30-publish-geo/README.md
@@ -10,21 +10,13 @@ Publishing your Geodata as Data Packages is very easy.
 
 You have two options for publishing your geodata:
 
-* **Geo Data Package** (Recommended). This is a basic Data Package with the
-  requirement that data be in GeoJSON and with a few special additions to the
-  metadata for geodata. See the next section for instructions on how to do
-  this - test
-* **Generic Data Package**. This allows you to publish geodata in any kind of
-  format (KML, Shapefiles, Spatialite etc). If you choose this option you will
-  want to follow the standard [instructions for packaging any kind of data as a
-  Data Package][pub-any].
+* **Geo Data Package** (Recommended). This is a basic Data Package with the requirement that data be in GeoJSON and with a few special additions to the metadata for geodata. See the next section for instructions on how to do this.
+* **Generic Data Package**. This allows you to publish geodata in any kind of format (KML, Shapefiles, Spatialite etc). If you choose this option you will want to follow the standard [instructions for packaging any kind of data as a Data Package][pub-any].
 
-We recommend Geo Data Package if that is possible as it makes it much easier
-for you to use 3rd party tools with your Data Package. For example, the [datapackage viewer][dp-viewer] on this site will automatically preview a Geo Data Package.
+We recommend Geo Data Package if that is possible as it makes it much easier for you to use 3rd party tools with your Data Package. For example, the [datapackage viewer][dp-viewer] on this site will automatically preview a Geo Data Package.
 
 ::: tip
-*Note: this document focuses on *vector* geodata &ndash; i.e. points, lines polygons etc (not
-imagery or raster data).*
+*Note: this document focuses on *vector* geodata &ndash; i.e. points, lines polygons etc (not imagery or raster data).*
 :::
 
 ## Geo Data Packages
@@ -35,7 +27,7 @@ imagery or raster data).*
 
 Example of using `point` geometries with described properties in real world situation.
 
-[View it with the Data Package Viewer][view-2]
+[View it with the Data Package Viewer][view-2](*deprecated*)
 
 [view-2]: http://data.okfn.org/tools/view?url=https%3A%2F%2Fgithub.com%2Fpeterdesmet%2Ftraffic-signs-hansbeke
 
@@ -44,7 +36,7 @@ Example of using `point` geometries with described properties in real world situ
 #### See more Geo Data Packages in the [example data packages](https://github.com/frictionlessdata/example-data-packages) GitHub repository.
 
 ::: tip
-Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
+Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our [Introduction][introduction].
 :::
 
 [dp]: /data-package
@@ -66,7 +58,7 @@ Recommended reading: Find out how to use Frictionless Data software to improve y
 [pub-any]: /blog/2016/07/21/publish-any/
 [pub-geo]: /blog/2016/04/30/publish-geo/
 [pub-faq]: /blog/2016/04/20/publish-faq/
-[field-guide]: /data-package
+[introduction]: /introduction
 
 [dp-creator]: http://create.frictionlessdata.io
 [dp-viewer]: http://create.frictionlessdata.io

--- a/site/blog/2016-07-21-creating-tabular-data-packages-in-python/README.md
+++ b/site/blog/2016-07-21-creating-tabular-data-packages-in-python/README.md
@@ -55,7 +55,7 @@ Let's say we have a file called `data.csv` ([download](https://github.com/fricti
 |  4             | Be     | Beryllium     | 9.012182                | alkaline earth metal  |
 |  5             | B      | Boron         | 10.811                  | metalloid             |
 
-We can extrapolate our CSV's [schema](/table-schema/) by using `infer` from the Table Schema library.  The `infer` function checks a small subset of your dataset and summarizes expected datatypes against each column, etc. To infer a schema for our dataset and view it, we will simply run
+We can extrapolate our CSV's schema by using `infer` from the Table Schema library.  The `infer` function checks a small subset of your dataset and summarizes expected datatypes against each column, etc. To infer a schema for our dataset and view it, we will simply run
 
 ```python
 package.infer('periodic-table/data.csv')

--- a/site/blog/2016-07-21-publish-any/README.md
+++ b/site/blog/2016-07-21-publish-any/README.md
@@ -10,38 +10,33 @@ category: publishing-data
 You can publish **all and any kind of data** as Data packages. It's as simple as 1-2-3:
 
 1. Get your data together
-2. Add a `datapackage.json` file to wrap those data files up into a useful
-   whole (with key information like the license, title and format)
+2. Add a `datapackage.json` file to wrap those data files up into a useful whole (with key information like the license, title and format)
 3. [optional] Share it with others, for example, by uploading the data package online
 
 ## 1. Get your data together
 
-Get your data together in one folder (you can have data in subfolders of that
-folder too, if you wish).
+Get your data together in one folder (you can have data in subfolders of that folder too, if you wish).
 
 ## 2. Add a datapackage.json file
 
-The `datapackage.json` is a small file in [JSON][json] format that describes
-your dataset. You'll need to create this file and then place it in the
-directory you created.
+The `datapackage.json` is a small file in [JSON][json] format that describes your dataset. You'll need to create this file and then place it in the directory you created.
 
-*Don't worry if you don't know what JSON is - we provide some tools such as [Data Package Creator][dp-creator] that can
-automatically create your this file for you.*
+*Don't worry if you don't know what JSON is - we provide some tools such as [Data Package Creator][dp-creator] that can automatically create this file for you.*
+
 
 There are 2 options for creating the `datapackage.json`:
 
-**Option 1**: Use the online [datapackage.json creator tool][dp-creator] - just
-answer a few questions and give it your data files and it will spit out a
-datapackage.json for you to include in your project
+**Option 1**: Use the online [datapackage.json creator tool][dp-creator] - just answer a few questions and give it your data files and it will spit out a datapackage.json for you to include in your project
 
-**Option 2**: Do it yourself - if you're familiar with JSON you can just create
-this yourself. Take a look at the [Data Package][dp] tutorial.
+**Option 2**: Do it yourself - if you're familiar with JSON you can create this yourself. Take a look at the [Data Package Specification][spec-dp].
 
 ## 3. Put the data package online
 
 See the [step-by-step instructions for putting your Data Package online][pub-online].
 
-Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
+::: tip
+Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our [Introduction][introduction].
+:::
 
 [dp]: /data-package
 [dp-main]: /data-package
@@ -62,7 +57,7 @@ Recommended reading: Find out how to use Frictionless Data software to improve y
 [pub-any]: /blog/2016/07/21/publish-any/
 [pub-geo]: /blog/2016/04/30/publish-geo/
 [pub-faq]: /blog/2016/04/20/publish-faq/
-[field-guide]: /data-package
+[introduction]: /introduction
 
 [dp-creator]: http://create.frictionlessdata.io
 [dp-viewer]: http://create.frictionlessdata.io

--- a/site/blog/2016-07-21-publish-tabular/README.md
+++ b/site/blog/2016-07-21-publish-tabular/README.md
@@ -6,62 +6,38 @@ description: A guide on how to publish tabular datapackages
 category: publishing-data
 ---
 
-Here's how to publish your tabular data as [Tabular Data
-Packages][tdp]. There are 4 simple steps:
+Here's how to publish your tabular data as [Tabular Data Packages][spec-tdp]. There are 4 steps:
 
 1. Create a folder (directory) - this folder will hold your "data package"
-2. Put your data into [CSV (comma-separated values)][csv]
-[csv]: /blog/2018/07/09/csv/
-   files and add them to that folder
-3. Add a `datapackage.json` file to hold some information about the data
-   package and the data in it e.g. a title, who created it, how other people
-   can use it (licensing), etc
+2. Put your data into comma-separated values files ([CSV][csv-blog]) and add them to that folder
+3. Add a `datapackage.json` file to hold some information about the data package and the data in it e.g. a title, who created it, how other people can use it (licensing), etc
 4. Upload the data package online
 
 ### 1. Create a Directory (Folder)
 
-We'll assume you know how to do this!
-
 ### 2. Create your CSV files
 
-CSV is a very common and very simple file format for storing a (single) table of
-data (for example, a single sheet in a spreadsheet). If you've got more than
-one table you can save multiple CSV files, one for each table.
+CSV is a common file format for storing a (single) table of data (for example, a single sheet in a spreadsheet). If you've got more than one table you can save multiple CSV files, one for each table.
 
-Put the CSV files in the directory you created -- we suggest putting them in a
-subdirectory called data so that your base directory does not get too cluttered
-up.
+Put the CSV files in the directory you created -- we suggest putting them in a subdirectory called `data` so that your base directory does not get too cluttered up.
 
-You can produce CSV files from almost any application that handles data including
-spreadsheets like Excel and databases like MySQL or Postgresql.
+You can produce CSV files from almost any application that handles data including spreadsheets like Excel and databases like MySQL or Postgresql.
 
-You can find out more about CSVs and how to produce them in our [guide to
-CSV][csv] or by doing a quick search online for CSV + the name of your tool.
-[csv]: /blog/2018/07/09/csv/
+You can find out more about CSVs and how to produce them in our [guide to CSV][csv-blog] or by doing a quick search online for CSV + the name of your tool.
 
 ### 3. Add a datapackage.json file
 
-The `datapackage.json` is a small file in [JSON][json] format that gives a bit of
-information about your dataset. You'll need to create this file and then place
-it in the directory you created.
-[json]: http://en.wikipedia.org/wiki/JSON
+The `datapackage.json` is a small file in [JSON][json] format that gives a bit of information about your dataset. You'll need to create this file and then place it in the directory you created.
 
-> *Don't worry if you don't know what JSON is - we provide some tools that can
-automatically create your this file for you.*
+> *Don't worry if you don't know what JSON is - we provide some tools that can automatically create your this file for you.*
 
 There are three options for creating the `datapackage.json`:
 
-**Option 1:** Use the online [datapackage.json creator tool][dp-creator] - just answer
-a few questions and give it your data files and it will spit out a
-datapackage.json for you to include in your project
+**Option 1:** Use the online [datapackage.json creator tool][dp-creator] - answer a few questions and give it your data files and it will spit out a `datapackage.json` for you to include in your project.
 
-**Option 2:** Do it yourself - if you're familiar with JSON you can just create
-this yourself. Take a look at the [Data Package][dp] and [Tabular Data
-Format][tdp] specs.
-[dp]: /data-package/
-[tdp]: /data-package/#tabular-data-package
+**Option 2:** Do it yourself - if you're familiar with JSON you can create this yourself. Take a look at the [Data Package][spec-dp] and [Tabular Data Format][spec-tdp] specifications.
 
-**Option 3:** Use the [Python][dp-py], [JavaScript][dp-js], [PHP][dp-php], [Julia][dp-jl], [R][dp-r], [Clojure][dp-clj], [Java][dp-java], [Ruby][dp-rb] or [Go][dp-go] libraries for working with data packages.
+**Option 3:** Use the Python, JavaScript, PHP, Julia, R, Clojure, Java, Ruby or Go [libraries][libraries] for working with data packages.
 
 ### 4. Put the data package online
 
@@ -78,15 +54,17 @@ Pay special attention to the scripts directory (and look at the commit logs!)
 - [datahub.io/core/co2-fossil-global](https://datahub.io/core/co2-fossil-global)
 - [datahub.io/core/imf-weo](https://datahub.io/core/imf-weo)
 
-Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
+::: tip
+Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our [introduction][introduction].
+:::
 
-
-[[dp]: /data-package
+[dp]: /data-package
 [dp-main]: /data-package
-[tdp]: /data-package/#tabular-data-package
 [ts]: /table-schema/
 [ts-types]: https://specs.frictionlessdata.io/table-schema/#field-descriptors
-[csv]: /blog/2018/07/09/csv/
+
+[csv-blog]: /blog/2018/07/09/csv/
+
 [json]: http://en.wikipedia.org/wiki/JSON
 
 [spec-dp]: https://specs.frictionlessdata.io/data-package/
@@ -104,3 +82,5 @@ Recommended reading: Find out how to use Frictionless Data software to improve y
 
 [dp-creator]: http://create.frictionlessdata.io
 [dp-viewer]: http://create.frictionlessdata.io
+[libraries]: /software
+[introduction]: /introduction

--- a/site/blog/2016-07-21-publish-tabular/README.md
+++ b/site/blog/2016-07-21-publish-tabular/README.md
@@ -78,7 +78,7 @@ Recommended reading: Find out how to use Frictionless Data software to improve y
 [pub-any]: /blog/2016/07/21/publish-any/
 [pub-geo]: /blog/2016/04/30/publish-geo/
 [pub-faq]: /blog/2016/04/20/publish-faq/
-[field-guide]: /data-package
+[field-guide]: /tag/field-guide
 
 [dp-creator]: http://create.frictionlessdata.io
 [dp-viewer]: http://create.frictionlessdata.io

--- a/site/blog/2016-08-29-using-data-packages-in-python/README.md
+++ b/site/blog/2016-08-29-using-data-packages-in-python/README.md
@@ -6,15 +6,15 @@ description: A guide on how to use datapackages with Python
 category: working-with-data-packages
 ---
 
-This tutorial will show you how to install the Python libraries for working with Tabular Data Packages and demonstrate a very simple example of loading a Tabular Data Package from the web and pushing it directly into a local SQL database. Short examples of pushing your dataset to Google’s BigQuery and Amazon’s RedShift follow.
+> This tutorial uses `datapackage-py` which has been replaced with `frictionless-py` (as of 2021). See the [Frictionless Framework documentation](https://framework.frictionlessdata.io/) for help with `frictionless-py`.
 
-<!-- more -->
+This tutorial will show you how to install the Python libraries for working with Tabular Data Packages and demonstrate a very simple example of loading a Tabular Data Package from the web and pushing it directly into a local SQL database. Short examples of pushing your dataset to Google’s BigQuery and Amazon’s RedShift follow.
 
 ## Setup
 
 For this tutorial, we will need the main Python Data Package library:
 
-<https://github.com/    /datapackage-py>
+<https://github.com/frictionlessdata/datapackage-py>
 
 You can install it as follows:
 
@@ -24,14 +24,7 @@ pip install datapackage
 
 ## Reading Basic Metadata
 
-In this case, we are using an example Tabular Data Package containing
-the periodic table stored on
-[GitHub](https://github.com/frictionlessdata/example-data-packages/tree/master/periodic-table)
-([datapackage.json](https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/periodic-table/datapackage.json),
-[data.csv](https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/periodic-table/data.csv)).
-This dataset includes the atomic number, symbol, element name, atomic
-mass, and the metallicity of the element.  Here are the first five
-rows:
+In this case, we are using an example Tabular Data Package containing the periodic table stored on [GitHub](https://github.com/frictionlessdata/example-data-packages/tree/master/periodic-table) ([datapackage.json](https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/periodic-table/datapackage.json), [data.csv](https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/periodic-table/data.csv)). This dataset includes the atomic number, symbol, element name, atomic mass, and the metallicity of the element.  Here are the first five rows:
 
 | atomic number | symbol | name      | atomic mass | metal or nonmetal?   |
 |---------------|--------|-----------|-------------|----------------------|
@@ -41,9 +34,7 @@ rows:
 | 4             | Be     | Beryllium | 9.012182    | alkaline earth metal |
 | 5             | B      | Boron     | 10.811      | metalloid            |
 
-You can start using the library by importing `datapackage`.  Data
-Packages can be loaded either from a local path or directly from the
-web.
+You can start using the library by importing `datapackage`.  Data Packages can be loaded either from a local path or directly from the web.
 
 ```python
 import datapackage
@@ -51,14 +42,7 @@ url = 'https://raw.githubusercontent.com/frictionlessdata/example-data-packages/
 dp = datapackage.Package(url)
 ```
 
-At the most basic level, Data Packages provide a standardized format
-for general metadata (for example, the dataset title, source, author,
-and/or description) about your dataset.  Now that you have loaded this
-Data Package, you have access to this metadata using the `metadata`
-dict attribute.  Note that these fields are optional and may not be
-specified for all Data Packages.  For more information on which fields
-are supported, see
-[the full Data Package standard][spec-dp].
+At the most basic level, Data Packages provide a standardized format for general metadata (for example, the dataset title, source, author, and/or description) about your dataset.  Now that you have loaded this Data Package, you have access to this metadata using the `metadata` dict attribute.  Note that these fields are optional and may not be specified for all Data Packages.  For more information on which fields are supported, see [the full Data Package standard](https://specs.frictionlessdata.io/data-package/).
 
 ```python
 print(dp.descriptor['title'])
@@ -67,16 +51,9 @@ print(dp.descriptor['title'])
 
 ## Reading Data
 
-Now that you have loaded your Data Package, you can read its data.  A
-Data Package can contain multiple files which are accessible via the
-`resources` attribute.  The `resources` attribute is an array of
-objects containing information (e.g. path, schema, description) about
-each file in the package.
+Now that you have loaded your Data Package, you can read its data.  A Data Package can contain multiple files which are accessible via the `resources` attribute.  The `resources` attribute is an array of objects containing information (e.g. path, schema, description) about each file in the package.
 
-You can access the data in a given resource in the `resources` array
-by reading the `data` attribute.  For example, using our our Periodic
-Table Data Package, we can return all elements with an atomic number
-of less than 10 by doing the following:
+You can access the data in a given resource in the `resources` array by reading the `data` attribute.  For example, using our our Periodic Table Data Package, we can return all elements with an atomic number of less than 10 by doing the following:
 
 ```python
 print([e['name'] for e in dp.resources[0].data if int(e['atomic number']) < 10])
@@ -84,8 +61,7 @@ print([e['name'] for e in dp.resources[0].data if int(e['atomic number']) < 10])
 > ['Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron', 'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine']
 ```
 
-If you don't want to load all data in memory at once, you can lazily
-access the data using the `iter()` method on the resource:
+If you don't want to load all data in memory at once, you can lazily access the data using the `iter()` method on the resource:
 
 ```python
 rows = dp.resources[0].iter()
@@ -104,11 +80,7 @@ rows.next()
 
 ## Loading into an SQL database
 
-[Tabular Data Packages](https://specs.frictionlessdata.io/tabular-data-package/) contains schema information about its
-data using [Table Schema](https://specs.frictionlessdata.io/table-schema/). This means you can easily import
-your Data Package into the SQL backend of your choice. In this case,
-we are creating an [SQLite](http://sqlite.org/) database in a new file
-named `datapackage.db`.
+[Tabular Data Packages](https://specs.frictionlessdata.io/tabular-data-package/) contains schema information about its data using [Table Schema](https://specs.frictionlessdata.io/table-schema/). This means you can easily import your Data Package into the SQL backend of your choice. In this case, we are creating an [SQLite](http://sqlite.org/) database in a new file named `datapackage.db`.
 
 To load the data into SQL we will need the Table Schema SQL Storage library:
 
@@ -135,12 +107,10 @@ dp.save(storage='sql', engine=engine)
 One way to check if your data has been saved successfully is by running
 
 ```Python
-list(engine.execute('SELECT * from data')))
+list(engine.execute('SELECT * from data'))
 ```
 
-Alternatively, if you have `sqlite3` installed, you can inspect and play with your
-newly created database.  Note that column type information has been
-translated from the Table Schema format to native SQLite types:
+Alternatively, if you have `sqlite3` installed, you can inspect and play with your newly created database.  Note that column type information has been translated from the Table Schema format to native SQLite types:
 
 ```sql
 $ sqlite3 periodic-table-datapackage.db
@@ -167,9 +137,7 @@ SELECT * from data;
 
 ## Loading into BigQuery
 
-Loading into BigQuery requires some setup on Google's infrastructure,
-but once that is completed, loading data can be just as frictionless.
-Here are the steps to follow:
+Loading into BigQuery requires some setup on Google's infrastructure, but once that is completed, loading data can be just as frictionless. Here are the steps to follow:
 
 1. Create a new project - [link](https://console.cloud.google.com/iam-admin/projects)
 2. Create a new service account key - [link](https://console.developers.google.com/apis/credentials)
@@ -207,8 +175,7 @@ table = Table('data.csv', schema='schema.json')
 table.save('data', storage='bigquery', service=service, project=project, dataset='dataset')
 ```
 
-If everything is in place, you should now be able to inspect your
-dataset on BigQuery.
+If everything is in place, you should now be able to inspect your dataset on BigQuery.
 
 ![BigQuery Schema](./bigquery-schema.png)
 
@@ -216,15 +183,9 @@ dataset on BigQuery.
 
 ## Loading into Amazon RedShift
 
-Similar to Google's BigQuery, Amazon RedShift requires
-[some setup](http://docs.aws.amazon.com/redshift/latest/gsg/getting-started.html)
-on AWS. Once you've created your cluster, however, all you need to do
-is use your cluster endpoint to create a connection string for
-SQLAlchemy.
+Similar to Google's BigQuery, Amazon RedShift requires [some setup](http://docs.aws.amazon.com/redshift/latest/gsg/getting-started.html) on AWS. Once you've created your cluster, however, all you need to do is use your cluster endpoint to create a connection string for SQLAlchemy.
 
-! Note: using the [sqlalchemy-redshift dialect](https://sqlalchemy-redshift.readthedocs.io/en/latest/index.html)
-is optional as the `postgres://` dialect is sufficient to load your
-table into AWS RedShift.
+! Note: using the [sqlalchemy-redshift dialect](https://sqlalchemy-redshift.readthedocs.io/en/latest/index.html) is optional as the `postgres://` dialect is sufficient to load your table into AWS RedShift.
 
 ![AWS RedShift](./aws-redshift-cluster-endpoint.png)
 
@@ -238,5 +199,5 @@ engine = create_engine(REDSHIFT_URL)
 dp.save(storage='sql', engine=engine)
 
 # check if data has been saved successfully
-list(engine.execute('SELECT * from data'))))
+list(engine.execute('SELECT * from data'))
 ```

--- a/site/blog/2016-08-30-publish/README.md
+++ b/site/blog/2016-08-30-publish/README.md
@@ -8,10 +8,7 @@ description: A guide on how to publish datapackages
 
 You can publish **any kind of data** as a Data Package.
 
-Making existing data into a Data Package is very simple.
-
-And once you have packaged up your data making it available for others is as
-simple as [putting it online][online] or sending an email.
+Making existing data into a Data Package is very straightforward. Once you have packaged up your data, you can make it available for others by [putting it online][online] or sending an email.
 
 [online]: /blog/2016/08/29/publish-online/
 
@@ -35,6 +32,6 @@ Any kind of data you have - graph, binary, RDF &hellip;
 
 [Here's a tutorial on publishing other types of data](/blog/2016/07/21/publish-any)
 
-Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
-
-[field-guide]: /data-package
+::: tip
+Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our [introduction](/introduction).
+:::

--- a/site/blog/2016-11-15-open-power-system-data/README.md
+++ b/site/blog/2016-11-15-open-power-system-data/README.md
@@ -3,10 +3,10 @@ title: Open Power System Data
 date: 2016-11-15
 tags: ["case-studies"]
 category: case-studies
-interviewee: Lion Hirth and Ingmar Schlecht
 subject_context: Open Power System Data uses Frictionless Data specifications to avail energy data for analysis and modeling
 image: /img/blog/opsd-logo.svg
 description: A free-of-charge and open platform providing the data needed for power system analysis and modeling.
+author: Lion Hirth and Ingmar Schlecht
 ---
 
 [Open Power System Data](http://open-power-system-data.org/) aims at providing a **free-of-charge** and **open** platform[^platform] that provides the data needed for power system analysis and modeling.
@@ -70,8 +70,7 @@ Advantages I see from those things are:
 * Ease of use for data consumers: They get what they want (filtered) in the format they prefer.
 * Implicitly that would also do a proper validation of the`datapackage.json`: Because if you have an error there, then things will also be messed up in the automatically generated files. So that also ensures good `datapackage.json` metadata quality in general which is important for all sorts of things you can do with Data Packages.
 
-Regarding the data processing workflow we created, I would refer you to our processingscripts[^scripts] on GitHub. I talked a lot about time series data – this should give you an [overview](https://github.com/Open-Power-System-Data/time_series/blob/master/main.ipynb);
-here are the [processing details](https://github.com/Open-Power-System-Data/time_series/blob/master/processing.ipynb).
+Regarding the data processing workflow we created, I would refer you to our processingscripts[^scripts] on GitHub. I talked a lot about time series data – this should give you an [overview](https://github.com/Open-Power-System-Data/time_series/blob/master/main.ipynb); here are the [processing details](https://github.com/Open-Power-System-Data/time_series/blob/master/processing.ipynb).
 
 In the coming days, we are going to extend the geographic scope and other various details---user friendliness, interpolation, data quality issues---so no big changes, just further work in the same direction.
 

--- a/site/blog/2016-11-15-tesera/README.md
+++ b/site/blog/2016-11-15-tesera/README.md
@@ -3,10 +3,10 @@ title: Tesera
 date: 2016-11-15
 tags: ["case-studies"]
 category: case-studies
-interviewee: Spencer Cox
 subject_context: Tesera uses Frictionless Data specifications to package data in readiness for use in different systems and components.
 image: /img/blog/tesera-logo.png
 description: Creating data-driven applications in the cloud.
+author: Spencer Cox
 ---
 
 Tesera is an employee-owned company, founded in 1997.  Our focus is helping our clients create data-driven applications in the cloud.  We also maintain two core product lines in addition to our consulting practice.  [MRAT.ca](https://www.linkedin.com/showcase/municipal-risk-assessment-tool/about/) helps municipalities identify risk of basement flooding, while [forestinventory.ca](https://cran.r-project.org/web/packages/forestinventory/index.html) (High Resolution Inventory Services) enables forest and natural resource companies to access a new level of accuracy and precision in resource inventories and carbon measurement.

--- a/site/blog/2017-03-28-john-snow-labs/README.md
+++ b/site/blog/2017-03-28-john-snow-labs/README.md
@@ -7,6 +7,7 @@ interviewee: Ida Lucente
 subject_context: John Snow Labs uses Frictionless Data specifications to avail data to users for analysis
 image: /img/blog/john-snow-labs-logo.png
 description: Turnkey data to data science, analytics and software teams in healthcare industry.
+author: Ida Lucente
 ---
 
 [John Snow Labs](https://www.johnsnowlabs.com/) accelerates data science and analytics teams, by providing clean, rich and current data sets for analysis. Our customers typically license between 50 and 500 data sets for a given project, so providing both data and metadata in a simple, standard format that is easily usable with a wide range of tools is important.
@@ -26,7 +27,7 @@ We are working with [Open Knowledge International](http://www.okfn.org/) on open
 
 The core use case we see for Frictionless Data specs is making data ready for analytics. There is a lot of Open Data out there, but a lot of effort is still required to make it usable. This single use case expands into as many variations as there are BI & data management tools, so we have many years of work ahead of us to address this one core use case.
 
-[^datapackage]: Data Package: [/data-package](/data-package)
+[^datapackage]: Data Package: [https://specs.frictionlessdata.io/data-package/](https://specs.frictionlessdata.io/data-package/)
 [^specs]: Frictionless Data Specifications [specs](https://specs.frictionlessdata.io/)
 [^elasticsearch]: Elastic Search <https://www.elastic.co/>
 [^kibana]: kibana <https://www.elastic.co/products/kibana>

--- a/site/blog/2017-04-11-dataworld/README.md
+++ b/site/blog/2017-04-11-dataworld/README.md
@@ -7,6 +7,7 @@ interviewee: Bryon Jacob
 subject_context: data.world uses Frictionless Data specifications to generate schema and metadata related to an uploaded dataset and containerize all three in a Tabular Data Package
 image: /img/blog/data-world-logo.png
 description: Allow users to download a version of a data.world dataset that retains the structured metadata and schema for offline analysis
+author: Bryon Jacob
 ---
 
 At [data.world][dataworld], we deal with a great diversity of data, both in terms of content and in terms of source format - most people working with data are emailing each other spreadsheets or CSVs, and not formally defining schema or semantics for what’s contained in these data files.

--- a/site/blog/2017-05-23-cmso/README.md
+++ b/site/blog/2017-05-23-cmso/README.md
@@ -7,6 +7,7 @@ interviewee: Paola Masuzzo
 subject_context: CMSO uses Frictionless Data specs to package cell migration data and load it into Pandas for data analysis and creation of visualizations.
 image: /img/blog/cmso-logo.png
 description: Building standards for cell migration data in order to enable data sharing in the field.
+author: Paola Masuzzo
 ---
 
 Researchers worldwide try to understand how cells move, a process extremely important for many physiological and pathological conditions. [Cell migration](https://en.wikipedia.org/wiki/Cell_migration) is in fact involved in many processes, like wound healing,neuronal development and cancer invasion. The [Cell Migration Standardization Organization](https://cmso.science/) (CMSO) is a community building standards for cell migration data, in order to enable data sharing in the field. The organization has three main working groups:

--- a/site/blog/2017-05-24-the-data-retriever/README.md
+++ b/site/blog/2017-05-24-the-data-retriever/README.md
@@ -7,6 +7,7 @@ interviewee: Ethan White
 subject_context: Data Retriever uses Frictionless Data specifications to generate and package metadata for publicly available data
 image: /img/blog/data-retriever-logo.png
 description: The Data Retriever is a package manager for data. It downloads, cleans, and stores publicly available data, so that analysts spend less time cleaning and managing data, and more time analyzing it.
+author: Ethan White
 ---
 
 [The Data Retriever](http://www.data-retriever.org/) automates the tasks of finding, downloading, and cleaning up publicly available data, and then stores them in a variety of databases and file formats. This lets data analysts spend less time cleaning up and managing data, and more time analyzing it.
@@ -47,5 +48,5 @@ Community contributions to our work are welcome. We work hard to make all of our
 [^tableschema]: Table Schema: [https://specs.frictionlessdata.io/table-schema](https://specs.frictionlessdata.io/table-schema)
 [^philosophy]: Design Philosophy: [/specs/#design-philosophy](https://specs.frictionlessdata.io/#design-philosophy)
 [^python]: Data Package-aware libraries in Python: <https://github.com/frictionlessdata/datapackage-py>, <https://github.com/frictionlessdata/tableschema-py>, <https://github.com/frictionlessdata/goodtables-py>
-[^version]: Data Package version field: [/specs/#version](https://specs.frictionlessdata.io/#version)
+[^version]: Data Package version field: [/specs/#version](https://specs.frictionlessdata.io/patterns/#data-package-version)
 [^yaml]: YAML Ain't Markup Language: <https://en.wikipedia.org/wiki/YAML>

--- a/site/blog/2017-06-26-pacific-northwest-national-laboratory-active-data-biology/README.md
+++ b/site/blog/2017-06-26-pacific-northwest-national-laboratory-active-data-biology/README.md
@@ -9,15 +9,13 @@ image: /img/blog/pnnl.png
 description: Using goodtables to validate metadata stored as part of an biological application on GitHub.
 ---
 
-
 ## Context
 
 ### Problem We Were Trying To Solve
 
 Sam Payne and his team at the Pacific Northwest National Laboratory (PNNL) have designed an application called [Active Data Biology](https://adbio.pnnl.gov/) (ADBio) which is an interactive web-based suite of tools for analyzing high-throughput omics (a set of related fields of study in biology).  The goal is to visualize and analyze datasets while still enabling seamless collaboration between computational and non-computational domain experts.  The tool provides several views on the same data facilitating different avenues of investigation.
 
-One of the high level goals of ADBio was to make collaborative data analysis work in a similar manner to collaborative software development (versioned, asynchronous, flexible, sharable, global). You can read more of the motivation in the Open Knowledge International blog post
-[Git for Data Analysis – why version control is essential for collaboration and for gaining public trust](https://blog.okfn.org/2016/11/29/git-for-data-analysis-why-version-control-is-essential-collaboration-public-trust/) written by Sam Payne as part of the pilot.  To facilitate this goal, Sam and his team used version-controlled repositories as the storage mechanism for all required resources. Data, software (for conducting analyses), and insights (gained from these analyses) for the project all get checked into the same repository.  ADBio pulls data and software directly from the repository and serves up an interactive visualization for data exploration. Any insight you choose to record gets checked back into the repository.
+One of the high level goals of ADBio was to make collaborative data analysis work in a similar manner to collaborative software development (versioned, asynchronous, flexible, sharable, global). You can read more of the motivation in the Open Knowledge International blog post [Git for Data Analysis – why version control is essential for collaboration and for gaining public trust](https://blog.okfn.org/2016/11/29/git-for-data-analysis-why-version-control-is-essential-collaboration-public-trust/) written by Sam Payne as part of the pilot.  To facilitate this goal, Sam and his team used version-controlled repositories as the storage mechanism for all required resources. Data, software (for conducting analyses), and insights (gained from these analyses) for the project all get checked into the same repository.  ADBio pulls data and software directly from the repository and serves up an interactive visualization for data exploration. Any insight you choose to record gets checked back into the repository.
 
 ![ADBio](./adbio.png)
 
@@ -80,11 +78,11 @@ Up to this point, the dataset provided by PNNL was adequately described by our s
 
 ### Software
 
-goodtables had [existed](http://okfnlabs.org/blog/2015/02/20/introducing-goodtables.html) as a Python library and web application developed by Open Knowledge International to support the validation of tabular datasets both in terms of structure and also with respect to a published schema as described above. This software was put to good use in a local government context.
+Goodtables had [existed](http://okfnlabs.org/blog/2015/02/20/introducing-goodtables.html) as a Python library and web application developed by Open Knowledge International to support the validation of tabular datasets both in terms of structure and also with respect to a published schema as described above. This software was put to good use in a local government context.
 
 For this pilot, and in coordination with other work in the project, we took the opportunity to drastically improve the software to support the online, automated validation referenced in the above use case.  We took as inspiration the workflow in use in software development environments around the world---continuous automated testing---and applied to data.  This involved not only updating the Python library to reflect the specification development to date, but the design of a new data publishing workflow that is applicable beyond PNNL’s needs. It is designed to be extensible, so that custom checks and custom backends (e.g. other places where one might publish a dataset) can take advantage of this workflow.  For example, in addition to datasets stored on GitHub, the new goodtables supports the automated validation of datasets stored on S3 and we are currently working on validation of datasets stored on CKAN.
 
-goodtables supports validation of tabular data in GitHub repositories to solve the use case for Active Data Biology.  On every update to the dataset, a validation task is run on the stored data.
+Goodtables supports validation of tabular data in GitHub repositories to solve the use case for Active Data Biology.  On every update to the dataset, a validation task is run on the stored data.
 
 ## Review
 
@@ -94,7 +92,7 @@ The omics team at PNNL are still investigating the use of goodtables.io for thei
 
 > We created a schema and started testing it. So far so good! I think this is going to work for a lot of projects which want to store data in a repo.
 
-As a real test of the generality of goodtables, we also tried to apply it to another project. This second project is a public repository describing measurements of metabolites in ion mobility mass spectrometry. Here, we are again using flat files for structured data. The data is actually a library of information describing metabolites, and we know that the library will be growing. So it was very similar to the ADBio project, in that the curated data would be continually updated. (see <https://github.com/PNNL-Comp-Mass-Spec/MetabolomicsCCS> for the project itself, and <https://github.com/PNNL-Comp-Mass-Spec/metaboliteValidation> for a validation script that leverages goodtables)
+As a real test of the generality of goodtables, we also tried to apply it to another project. This second project is a public repository describing measurements of metabolites in ion mobility mass spectrometry. Here, we are again using flat files for structured data. The data is actually a library of information describing metabolites, and we know that the library will be growing. So it was very similar to the ADBio project, in that the curated data would be continually updated. (see <https://github.com/PNNL-Comp-Mass-Spec/MetabolomicsCCS> for the project itself, and <https://github.com/PNNL-Comp-Mass-Spec/metaboliteValidation> for a validation script that leverages goodtables).
 
 Of course, technical issues that they have encountered have been translated in GitHub issues and are being addressed:
 

--- a/site/blog/2017-09-28-zegami/README.md
+++ b/site/blog/2017-09-28-zegami/README.md
@@ -7,6 +7,7 @@ interviewee: Roger Noble and Andrew Stretton
 subject_context: Zegami is using Frictionless Data specifications for data management and syntactic analysis on their visual data analysis platform
 image: /img/blog/zegami-logo.png
 description:  As a visual data exploration and analytics platform, Zegami makes the exploration of large collections of image rich information quick and simple.
+author: Roger Noble and Andrew Stretton
 ---
 
 [Zegami](https://www.zegami.com) makes information more visual and accessible, enabling intuitive exploration, search and discovery of large data sets. Zegami combines the power of machine learning and human pattern recognition to reveal hidden insights and new perspectives.
@@ -52,9 +53,8 @@ In terms of the next steps for us, we are currently working on a SaaS implementa
 [^handsontable]: Handsontable: Javascript spreadsheet component for web apps: <https://handsontable.com>
 [^dpp]: Data Package Pipelines: <https://github.com/frictionlessdata/datapackage-pipelines>
 [^dask]:Dask Custom Graphs: <http://dask.pydata.org/en/latest/custom-graphs.html>
-[^datapackage]: Data Packages: [/data-package](/data-package)
+[^datapackage]: Data Packages: [https://specs.frictionlessdata.io/data-package](https://specs.frictionlessdata.io/data-package)
 [^dreamfactory]: Dream Factory: <https://www.dreamfactory.com/>
-[wqio]: https://wq.io/
 [^ckan]: CKAN: Open Source Data Portal Platform: <https://ckan.org>
 [^pydata]: PyData London, October 2017 Meetup: <https://www.meetup.com/PyData-London-Meetup/events/243584161/>
 [^pyconuk]: PyCon UK 2017 Schedule: <http://2017.pyconuk.org/schedule/>

--- a/site/blog/2017-12-12-ukds/README.md
+++ b/site/blog/2017-12-12-ukds/README.md
@@ -24,7 +24,7 @@ We worked with data that was publicly accessible, and therefore in its post-publ
 
 The UK Data Service offers an online repository where researchers can archive, publish and share research data, called [Reshare](http://reshare.ukdataservice.ac.uk/). Reshare exposes an [OAI-PMH](https://www.openarchives.org/pmh/) endpoint to facilitate metadata harvesting.
 
-[datahub.io](http://datahub.io/) is a data workflows web application build around the modular Frictionless Data toolchain, designed to find, share and publish high quality data online. Each entry has a ‘Showcase’ to display data package properties, and preview data with tables and simple visualisations. As well as the Showcase, [datahub.io](http://datahub.io/) provides straight-forward direct access to import data into a variety of tools used by researchers; R, Pandas, Python, JavaScript, and SQL. [Frictionless Data Data Packages](/data-package/) can be pushed to datahub.io to create dataset entries.
+[datahub.io](http://datahub.io/) is a data workflows web application build around the modular Frictionless Data toolchain, designed to find, share and publish high quality data online. Each entry has a ‘Showcase’ to display data package properties, and preview data with tables and simple visualisations. As well as the Showcase, [datahub.io](http://datahub.io/) provides straight-forward direct access to import data into a variety of tools used by researchers; R, Pandas, Python, JavaScript, and SQL. [Frictionless Data Data Packages](https://specs.frictionlessdata.io/data-package/) can be pushed to datahub.io to create dataset entries.
 
 ### Problem We Were Trying To Solve
 

--- a/site/blog/2017-12-19-dm4t/README.md
+++ b/site/blog/2017-12-19-dm4t/README.md
@@ -24,9 +24,8 @@ Energy Data
 - Frictionless Data specs: http://specs.frictionlessdata.io/
 - Data Package Pipelines: https://github.com/frictionlessdata/datapackage-pipelines
 - Goodtables: https://github.com/frictionlessdata/goodtables-py
-- Packagist: https://packagist.org/
 
-packagist.io has now moved to [create.frictionlessdata.io](http://create.frictionlessdata.io)
+`packagist` has now moved to [create.frictionlessdata.io](http://create.frictionlessdata.io)
 
 ## Context
 
@@ -298,7 +297,7 @@ DATASET
 
 ### Modifying a data package using Packagist
 
-If we need to modify our data package, we could use the [Packagist](./packagist.io). It incorporates a straightforward UI to modify and validate data package descriptors. With its easy to use interface we are able to:
+If we need to modify our data package, we could use the [Packagist](https://create.frictionlessdata.io/). It incorporates a straightforward UI to modify and validate data package descriptors. With its easy to use interface we are able to:
 
 - Load/validate/save a data package
 - Update a data package metadata

--- a/site/blog/2018-02-14-creating-tabular-data-packages-in-r/README.md
+++ b/site/blog/2018-02-14-creating-tabular-data-packages-in-r/README.md
@@ -173,7 +173,7 @@ Now that you have created a data package in R, [find out how to use data package
 [toolfund]: https://toolfund.frictionlessdata.io
 [toolfund-okgreece]:https://frictionlessdata.io/articles/open-knowledge-greece/
 [dp-r]: https://github.com/frictionlessdata/datapackage-r
-[ts]: /table-schema/
+[ts]: https://specs.frictionlessdata.io/table-schema/
 [r-devtools]: https://cran.r-project.org/package=devtools
 [fd-gitter]: http://gitter.im/frictionlessdata/chat
 [dp-r-issues]: https://github.com/frictionlessdata/datapackage-r/issues

--- a/site/blog/2018-02-14-using-data-packages-in-r/README.md
+++ b/site/blog/2018-02-14-using-data-packages-in-r/README.md
@@ -7,12 +7,13 @@ description: A guide on how to use datapackage with R
 category: working-with-data-packages
 ---
 
-
 [Open Knowledge Greece][okgreece] was one of 2017's [Frictionless Data Tool Fund][toolfund] grantees tasked with extending implementation of core Frictionless Data libraries in R programming language. You can read more about this in [their grantee profile][toolfund-okgreece]. In this tutorial, [Kleanthis Koupidis](https://gr.linkedin.com/in/kleanthis-koupidis-8348b88b), a Data Scientist and Statistician at Open Knowledge Greece, explains how to work with Data Packages in R.
 
 This tutorial will show you how to install the R libraries for working with Tabular Data Packages and demonstrate a very simple example of loading a Tabular Data Package from the web and pushing it directly into a local SQL database and send query to retrieve results.
 
+::: tip
 For a comprehensive introduction to creating tabular data packages in R, [start by going through this tutorial][create-r].
+:::
 
 ## Setup
 
@@ -175,7 +176,7 @@ We welcome your feedback and questions via our [Frictionless Data Gitter chat][f
 [toolfund]: https://toolfund.frictionlessdata.io
 [toolfund-okgreece]:https://frictionlessdata.io/articles/open-knowledge-greece/
 [dp-r]: https://github.com/frictionlessdata/datapackage-r
-[ts]: /table-schema/
+[ts]: https://specs.frictionlessdata.io/table-schema/
 [r-devtools]: https://cran.r-project.org/package=devtools
 [fd-gitter]: http://gitter.im/frictionlessdata/chat
 [dp-r-issues]: https://github.com/frictionlessdata/datapackage-r/issues

--- a/site/blog/2018-03-07-well-packaged-datasets/README.md
+++ b/site/blog/2018-03-07-well-packaged-datasets/README.md
@@ -1,7 +1,7 @@
 ---
 title: Well packaged datasets
 date: 2018-03-07
-tags: ["Data Package Creator"]
+tags: ["Data Package Creator", "field-guide"]
 category: 
 image: /img/blog/well-packaged.png
 description: There's an art to creating a good collection of data. Improve the quality of your datasets; making use of schemas, metadata, and data packages.

--- a/site/blog/2018-03-12-automatically-validated-tabular-data/README.md
+++ b/site/blog/2018-03-12-automatically-validated-tabular-data/README.md
@@ -1,7 +1,7 @@
 ---
 title: Automatically validated tabular data
 date: 2018-03-12
-tags: ["goodtables.io"]
+tags: ["goodtables.io", "field-guide"]
 category: 
 image: /img/blog/auto-validate.png
 description: Automatic validation means you'll be the first to know if a change in your data causes a problem. Learn how to incorporate automatic validation into your workflow.

--- a/site/blog/2018-03-12-automatically-validated-tabular-data/README.md
+++ b/site/blog/2018-03-12-automatically-validated-tabular-data/README.md
@@ -53,7 +53,7 @@ Once you have tabular data in your Github repository:
 1. Once we've synchronized your repository list, go to the [Manage Sources](https://goodtables.io/settings) page and enable the repository with the data you want to validate.
     * If you can't find the repository, try clicking on the Refresh button on the Manage Sources page
 
-Goodtables will then validate all tabular data files (CSV, XLS, XLSX, ODS) and [data packages](/data-package/) in the repository. These validations will be executed on every change, including pull requests.
+Goodtables will then validate all tabular data files (CSV, XLS, XLSX, ODS) and [data packages](https://specs.frictionlessdata.io/data-package/) in the repository. These validations will be executed on every change, including pull requests.
 
 
 ## Validate tabular data automatically on Amazon S3

--- a/site/blog/2018-03-12-data-publication-workflow-example/README.md
+++ b/site/blog/2018-03-12-data-publication-workflow-example/README.md
@@ -1,7 +1,7 @@
 ---
 title: Data publication workflow example
 date: 2018-03-12
-tags: ["Data Package Creator", "goodtables.io"]
+tags: ["Data Package Creator", "goodtables.io", "field-guide"]
 category:
 image: /img/blog/workflow.png
 description: There's a lot to see in the world of Frictionless Data. If you're confused about how it all comes together, take a look at our publication workflow example.

--- a/site/blog/2018-03-27-applying-licenses/README.md
+++ b/site/blog/2018-03-27-applying-licenses/README.md
@@ -57,7 +57,7 @@ folder
 
 It is recommended that the licence is provided in [markdown](http://commonmark.org) format to simplify its display in data platforms and other software.
 
-The license can be a separate file or included in the README.md file. If license information is included in the README.md file, it is recommended that it follows the [guide for formatting a README file](/blog/2016/04/20/publish-faq/#readme).
+The license can be a separate file or included in the `README.md` file. If license information is included in the `README.md` file, it is recommended that it follows the [guide for formatting a README file](/blog/2016/04/20/publish-faq/#readme).
 
 ## Applying a license
 
@@ -160,7 +160,7 @@ Some data publishers may waive some of their rights under a license, e.g.
 > Noosa Shire Council waives the requirements of attribution under this licence, for this data.
 
 You can include this information, either:
-* in the file containing license information (e.g. README.md)
+* in the file containing license information (e.g. `README.md`)
 * as additional metadata properties in the datapackage.json
 
 The data package specification supports adding [additional metadata properties](https://specs.frictionlessdata.io/data-package/#descriptor) to the datapackage.json, e.g.
@@ -204,7 +204,7 @@ Sometimes data in a resource may be combined from multiple sources that are lice
 ```
 
 ### License may become legally binding
-frictionlessdata.io
+
 The [specification](https://specs.frictionlessdata.io/data-package/#licenses) for `licenses` states:
 
 > **This property is not legally binding and does not guarantee the package is licensed under the terms defined in this property.**
@@ -218,7 +218,7 @@ Be aware that some data platforms or software may not fully support the Friction
 For example, at the time of writing:
 
 * [CKAN Data Package extension](https://github.com/frictionlessdata/ckanext-datapackager):
-  * does not upload the README.md file in a data package. If you have described licence information in the README.md file, this will be lost ([issue #60](https://github.com/frictionlessdata/ckanext-datapackager/issues/60))
+  * does not upload the `README.md` file in a data package. If you have described licence information in the `README.md` file, this will be lost ([issue #60](https://github.com/frictionlessdata/ckanext-datapackager/issues/60))
   * does not display license information in the datapackage.json file correctly ([issue #62](https://github.com/frictionlessdata/ckanext-datapackager/issues/62))
 
 * [Data Curator](/blog/2019/03/01/datacurator/) only allows the user to select from a limited set of open licenses to describe the data package and data resource licenses.

--- a/site/blog/2018-04-04-creating-tabular-data-packages-in-javascript/README.md
+++ b/site/blog/2018-04-04-creating-tabular-data-packages-in-javascript/README.md
@@ -7,8 +7,6 @@ category: working-with-data-packages
 
 This tutorial will show you how to install the JavaScript libraries for working with Data Packages and Table Schema, load a CSV file, infer its schema, and write a Tabular Data Package.
 
-<!-- more -->
-
 ## Setup
 
 For this tutorial we will need [datapackage-js](https://github.com/frictionlessdata/datapackage-js) which is a JavaScript library for working with Data Packages.
@@ -34,6 +32,4 @@ This creates a `datapackage.json` file in this directory.
 
 ## Publishing
 
-Now that you have created your Data Package, you might want to
-[publish your data online](/blog/2016/08/29/publish-online/) so that you can
-share it with others.
+Now that you have created your Data Package, you might want to [publish your data online](/blog/2016/08/29/publish-online/) so that you can share it with others.

--- a/site/blog/2018-04-05-joining-tabular-data-in-python/README.md
+++ b/site/blog/2018-04-05-joining-tabular-data-in-python/README.md
@@ -7,8 +7,6 @@ category: working-with-data-packages
 
 In a [separate guide](/blog/2018/04/06/joining-data-in-python/), I walked through joining a tabular dataset with one containing geographic information.  In this guide, I will demonstrate an example of joining two tabular datasets.
 
-<!-- more -->
-
 There are, of course, various, more robust ways of joining tabular data.  The example listed below is intended to demonstrate how the current libraries and specifications work together to perform this common task.
 
 ## Data
@@ -47,7 +45,7 @@ cpi_dp = datapackage.DataPackage('https://raw.githubusercontent.com/frictionless
 gdp_dp = datapackage.DataPackage('https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/gross-domestic-product-all/datapackage.json')
 ```
 
-Given that our source data has already been packaged in [Tabular Data Package](/data-package/#tabular-data-package) format, we know that we have a [*schema*](/table-schema) for each CSV which specifies useful information for each column.  We'd like to merge and preserve this schema information as we'll need it for specifying the combined schema in our new Data Package.  Note that we're also adding a new derived column named 'Real GDP' and giving it a type of `number`.
+Given that our source data has already been packaged in [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-package/) format, we know that we have a [*schema*](https://specs.frictionlessdata.io/table-schema) for each CSV which specifies useful information for each column.  We'd like to merge and preserve this schema information as we'll need it for specifying the combined schema in our new Data Package.  Note that we're also adding a new derived column named 'Real GDP' and giving it a type of `number`.
 
 ```python
 field_info = []

--- a/site/blog/2018-04-06-joining-data-in-python/README.md
+++ b/site/blog/2018-04-06-joining-data-in-python/README.md
@@ -25,7 +25,7 @@ For this example, we are going to use two example Data Packages from our [exampl
       "geometry": {
         "type": "Polygon",
         "coordinates": [
-        ...
+        "..."
         ]
       }
     }
@@ -33,7 +33,7 @@ For this example, we are going to use two example Data Packages from our [exampl
 }
 ```
 
-The second Data Package is a typical [Tabular Data Package](/data-package/#tabular-data-package) containing a GDP measure for each country in the world for the year 2014. Country codes are stored, naturally, on the "Country Code" column.
+The second Data Package is a typical [Tabular Data Package](https://specs.frictionlessdata.io/tabular-data-package) containing a GDP measure for each country in the world for the year 2014. Country codes are stored, naturally, on the "Country Code" column.
 
 |  Country Name                                   | Country Code | Year | Value             |
 |-------------------------------------------------|--------------|------|-------------------|

--- a/site/blog/2018-07-09-developer-guide/README.md
+++ b/site/blog/2018-07-09-developer-guide/README.md
@@ -6,7 +6,7 @@ category: contributing
 ---
 
 
-This guide introduces you to the Frictionless Data tool stack and how you can contribute to it.
+This guide introduces you to the Frictionless Data tool stack and how you can contribute to it. *Update note (2021): this blog is out of date. Please see the [contributing guide](/work-with-us/contribute/) for updated information.*
 
 <!-- more -->
 
@@ -30,12 +30,12 @@ We have prepared a variety of example and test data packages for use in developm
 
 This entity diagram gives an overview of how the main different objects fit together. The top row is a generic Data Package and the row below shows the case of Tabular Data Package.
 
-This guide will focus on [Tabular Data Packages][tdp] as that is the most commonly used form of Data Packages and is suited to most tools.
+This guide will focus on [Tabular Data Packages][spec-tdp] as that is the most commonly used form of Data Packages and is suited to most tools.
 
 ![overview of data packages and tabular data packages](./overview-of-data-packages.png)
 *overview of data packages and tabular data packages*
 
-This guide will assume you already have some high-level familiarity with the [Data Package family of specifications][dp-main]. Please a take a few minutes to take a look at the [overview][dp-main] if you are not yet familiar with those specs.
+This guide will assume you already have some high-level familiarity with the [Data Package family of specifications][spec-dp]. Please a take a few minutes to take a look at the [overview][dp-main] if you are not yet familiar with those specs.
 
 ## Implementing a Data Package Tool Stack
 
@@ -200,7 +200,7 @@ Following "Node" style we have partitioned the Javascript library into pieces, s
 Related blog post: <http://okfnlabs.org/blog/2017/10/05/frictionless-data-specs-v1-updates.html>
 
 [dp]: /data-package
-[dp-main]: /data-package
+[dp-main]: /introduction
 [tdp]: /data-package/#tabular-data-package
 [ts]: /table-schema/
 [ts-types]: https://specs.frictionlessdata.io/table-schema/#field-descriptors

--- a/site/blog/2018-07-09-validating-data/README.md
+++ b/site/blog/2018-07-09-validating-data/README.md
@@ -19,24 +19,19 @@ We will walk through two methods of performing validation:
 
 ## goodtables
 
-[goodtables](http://goodtables.io/) is a free, open-source, hosted
-service for validating tabular data. goodtables checks your data for
-its *structure*, and, optionally, its adherence to a specified *schema*. Where the latter fails, goodtables highlights content errors so you can fix them speedily.
+[goodtables](http://goodtables.io/) is a free, open-source, hosted service for validating tabular data. goodtables checks your data for its *structure*, and, optionally, its adherence to a specified *schema*. Where the latter fails, goodtables highlights content errors so you can fix them speedily.
 
-goodtables will give quick and simple feedback on where your tabular
-data may not yet be quite perfect.
+goodtables will give quick and simple feedback on where your tabular data may not yet be quite perfect.
 
 ![goodtables screenshot](./goodtables-screenshot.png)
 
-To get started with one-off validation of your tabular datasets, use [try.goodtables.io](http://try.goodtables.io). All you need to do is upload or provide a link to a CSV
-file and hit the "Validate" button.
+To get started with one-off validation of your tabular datasets, use [try.goodtables.io](http://try.goodtables.io). All you need to do is upload or provide a link to a CSV file and hit the "Validate" button.
 
 ![goodtables Provide URL](./goodtables-provide-data.png)
 
 ![goodtables Validate button](./goodtables-validate.png)
 
-If your data is structurally valid, you should receive the following
-result:
+If your data is structurally valid, you should receive the following result:
 
 ![goodtables Valid](./goodtables-valid.png)
 
@@ -44,27 +39,17 @@ If not...
 
 ![goodtables Invalid](./goodtables-invalid.png)
 
-The report should highlight the structural issues found in your data
-for correction.  For instance, a poorly structured tabular dataset may
-consist of a header row with too many (or too few) columns when
-compared to of data rows with an equal amount of columns.
+The report should highlight the structural issues found in your data for correction.  For instance, a poorly structured tabular dataset may consist of a header row with too many (or too few) columns when compared to of data rows with an equal amount of columns.
 
-You can also provide a schema for your tabular data defined using JSON
-Table Schema.
+You can also provide a schema for your tabular data defined using JSON Table Schema.
 
 ![goodtables Provide Schema](./goodtables-provide-schema.png)
 
-Briefly, the format allows users to specify not only
-the types of information within each column in a tabular dataset, but
-also expected values.  For more information, see the
-[Table Schema guide](/table-schema/) or
-[the full standard](https://specs.frictionlessdata.io/table-schema/).
+Briefly, the format allows users to specify not only the types of information within each column in a tabular dataset, but also expected values.  For more information, see the [introduction](/introduction/) or [the full standard](https://specs.frictionlessdata.io/table-schema/).
 
 ## Python + goodtables
 
-goodtables is also available as a Python library.  The following short
-snippets demonstrate examples of loading and validating data in a file
-called `data.csv`(and in the second example, validating the same data file against `schema.json`)
+goodtables is also available as a Python library.  The following short snippets demonstrate examples of loading and validating data in a file called `data.csv`(and in the second example, validating the same data file against `schema.json`)
 
 ### Validating Structure
 
@@ -113,7 +98,7 @@ Find more examples on validating tabular data in the [Frictionless Data Field Gu
 [ts-types]: https://specs.frictionlessdata.io/table-schema/#field-descriptors
 [csv]: /blog/2018/07/09/csv/
 [json]: http://en.wikipedia.org/wiki/JSON
-[field-guide]: /data-package
+[field-guide]: /tag/field-guide
 
 [spec-dp]: https://specs.frictionlessdata.io/data-package/
 [spec-tdp]: https://specs.frictionlessdata.io/tabular-data-package/

--- a/site/blog/2018-07-16-publish-data-as-data-packages/README.md
+++ b/site/blog/2018-07-16-publish-data-as-data-packages/README.md
@@ -19,7 +19,7 @@ You can package any kind of data as a Data Package.
 
 Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
 
-[field-guide]: /data-package
+[field-guide]: /tag/field-guide
 
 [dp-creator]: http://create.frictionlessdata.io
 

--- a/site/blog/2018-07-16-validated-tabular-data/README.md
+++ b/site/blog/2018-07-16-validated-tabular-data/README.md
@@ -1,7 +1,7 @@
 ---
 title: Validated tabular data
 date: 2018-07-16
-tags: ["try.goodtables.io", "Goodtables CLI"]
+tags: ["try.goodtables.io", "Goodtables CLI", "field-guide"]
 category:
 image: /img/blog/valid.png
 description: When it comes to validating tabular data, you have some great tools at your disposal. We take a look at a couple of ways to utilise goodtables.

--- a/site/blog/2018-07-16-visible-findable-shareable-data/README.md
+++ b/site/blog/2018-07-16-visible-findable-shareable-data/README.md
@@ -1,7 +1,7 @@
 ---
 title: Visible, findable, shareable data
 date: 2018-07-16
-tags: ["Goodtables"]
+tags: ["Goodtables", "field-guide"]
 category:
 image: /img/blog/visible.png
 description: Getting your data out into the world is a crucial step towards its being used and useful. We walk through the steps to publishing on the top data platforms.

--- a/site/blog/2018-08-29-publish-online/README.md
+++ b/site/blog/2018-08-29-publish-online/README.md
@@ -1,7 +1,7 @@
 ---
 title: Publish Your Data Package Online
 date: 2016-08-29
-tags: ["field-guide"]
+tags:
 category: publishing-data
 ---
 

--- a/site/blog/2018-08-29-publish-online/README.md
+++ b/site/blog/2018-08-29-publish-online/README.md
@@ -1,13 +1,11 @@
 ---
 title: Publish Your Data Package Online
 date: 2016-08-29
-tags:
+tags: ["field-guide"]
 category: publishing-data
 ---
 
 This tutorial is about how to publish your Data Package online for others to find and use.
-
-<!-- more -->
 
 It assumes you have already finished packaging up your data as a Data Package (if not, [check out the instructions here](/blog/2018/07/16/publish-data-as-data-packages/)).
 
@@ -97,4 +95,4 @@ mind:
 
 Recommended reading: Find out how to use Frictionless Data software to improve your data publishing workflow in our new and comprehensive [Frictionless Data Field Guide][field-guide].
 
-[field-guide]: /data-package
+[field-guide]: /tag/field-guide

--- a/site/blog/2019-05-20-used-and-useful-data/README.md
+++ b/site/blog/2019-05-20-used-and-useful-data/README.md
@@ -1,7 +1,7 @@
 ---
 title: Used and useful data
 date: 2019-05-20
-tags: ["Data Package Creator", "goodtables.io", "Command-line"]
+tags: ["Data Package Creator", "goodtables.io", "Command-line", "field-guide"]
 category:
 image: /img/blog/used.png
 description: Concerned that your data is just not being used? We've got some great tips, and best practices to improve the uptake in your data use


### PR DESCRIPTION
This fixes typos and broken URLs in several old blogs that were caused when they were transferred to the new site.
It also creates a new tag "field-guide" so we can easily find & link to the field guide content.

Can you please take a look when you have time @roll? (this is not urgent) Thanks!
