### PR TITLE
Remove Google Analytics and add Plausible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1842,12 +1842,6 @@
         "vuepress-plugin-sitemap": "^2.3.1"
       }
     },
-    "@vuepress/plugin-google-analytics": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.8.2.tgz",
-      "integrity": "sha512-BMFayLzT2BvXmnhM9mDHw0UPU7J0pH1X9gQA4HmZxOf7f3+atK5eJGsc1Ia/+1FTG2ESvhFLUU/CC3h5arjEJw==",
-      "dev": true
-    },
     "@vuepress/plugin-last-updated": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@vuepress/plugin-last-updated/-/plugin-last-updated-1.8.2.tgz",
@@ -10252,6 +10246,12 @@
         "find-up": "^4.0.0"
       }
     },
+    "plausible-tracker": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.5.tgz",
+      "integrity": "sha512-6c6VPdPtI9KmIsfr8zLBViIDMt369eeaNA1J8JrAmAtrpSkeJWvjwcJ+cLn7gVJn5AtQWC8NgSEee2d/5RNytA==",
+      "dev": true
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -13660,6 +13660,15 @@
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
+      }
+    },
+    "vue-plausible": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vue-plausible/-/vue-plausible-1.3.1.tgz",
+      "integrity": "sha512-OqZiScz/7glitE4XSJTwGUHO31VEbba2efmLki0+rIGDx3NysSOBJMyFz6yBFPWKms4jb1lDmx1wCsbAl7mrtA==",
+      "dev": true,
+      "requires": {
+        "plausible-tracker": "^0.3.4"
       }
     },
     "vue-property-decorator": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@vssue/vuepress-plugin-vssue": "^1.4.8",
     "@vuepress/plugin-back-to-top": "^1.8.2",
     "@vuepress/plugin-blog": "^1.9.4",
-    "@vuepress/plugin-google-analytics": "^1.8.2",
     "dotenv": "^10.0.0",
     "lodash": "^4.17.21",
     "markdown-it-footnote": "",
@@ -24,6 +23,7 @@
     "vue-typed-js": "^0.1.2",
     "vuepress": "^1.8.2",
     "vuepress-plugin-dehydrate": "^1.1.5",
-    "vuepress-plugin-feed": "^0.1.9"
+    "vuepress-plugin-feed": "^0.1.9",
+    "vue-plausible": "^1.3.1"
   }
 }

--- a/site/.vuepress/config.js
+++ b/site/.vuepress/config.js
@@ -146,12 +146,6 @@ module.exports = {
   },
   plugins: [
     [
-      "@vuepress/plugin-google-analytics",
-      {
-        ga: "UA-33874954-38",
-      },
-    ],
-    [
       "@vuepress/blog",
       {
         directories: [

--- a/site/.vuepress/theme/components/Home.vue
+++ b/site/.vuepress/theme/components/Home.vue
@@ -36,6 +36,14 @@
 
 <script>
 import Vue from "vue";
+import { VuePlausible } from 'vue-plausible'
+
+Vue.use(VuePlausible, {
+  domain: "frictionlessdata.io",
+  trackLocalhost: false,
+  enableAutoPageviews: true,
+  enableAutoOutboundTracking: true,
+})
 
 export default {
   computed: {


### PR DESCRIPTION
Not sure on this. I'm not vue.js developer

It's working fine locally. I was able to track the homepage locally

![image](https://user-images.githubusercontent.com/3237309/160700794-dfb9be3e-4c19-4969-a96c-fa0879add323.png)

Not sure if this is the right way to remove Google Analytics and add Plausible
I followed the [integration guidelines](https://plausible.io/docs/integration-guides) from Plausible for Vue.js
The [vue-plausible package](https://github.com/moritzsternemann/vue-plausible) was installed.

